### PR TITLE
upgrade chart versions

### DIFF
--- a/charts/jenkins-x/jenkins-x-platform.yml
+++ b/charts/jenkins-x/jenkins-x-platform.yml
@@ -1,2 +1,2 @@
-version: 0.0.3368
+version: 0.0.3373
 gitUrl: https://github.com/jenkins-x/jenkins-x-platform

--- a/charts/jenkins-x/jx-build-templates.yml
+++ b/charts/jenkins-x/jx-build-templates.yml
@@ -1,2 +1,2 @@
-version: 0.0.389
+version: 0.0.407
 gitUrl: https://github.com/jenkins-x-charts/jx-build-templates

--- a/charts/jenkins-x/knative-build-pipeline.yml
+++ b/charts/jenkins-x/knative-build-pipeline.yml
@@ -1,2 +1,2 @@
-version: 0.0.14
+version: 0.0.16
 gitUrl: https://github.com/jenkins-x-charts/knative-build-pipeline

--- a/charts/jenkins-x/prow.yml
+++ b/charts/jenkins-x/prow.yml
@@ -1,2 +1,2 @@
-version: 0.0.187
+version: 0.0.204
 gitUrl: https://github.com/jenkins-x-charts/prow


### PR DESCRIPTION
change `jenkins-x/jenkins-x-platform` to version `0.0.3373`
change `jenkins-x/jx-build-templates` to version `0.0.407`
change `jenkins-x/knative-build-pipeline` to version `0.0.16`
change `jenkins-x/prow` to version `0.0.204`
