### PR TITLE
roll forward to sso-operator 1.2.7

### DIFF
--- a/charts/jenkins-x/sso-operator.yml
+++ b/charts/jenkins-x/sso-operator.yml
@@ -1,2 +1,2 @@
-version: 1.2.6
+version: 1.2.7
 gitUrl: https://github.com/jenkins-x/sso-operator


### PR DESCRIPTION
the 1.2.6 chart for some reason did not get published, 1.2.7 is a
rerelease of 1.2.6 so roll forward to that