### PR TITLE
upgrade chart versions

### DIFF
--- a/charts/jenkins-x/dex.yml
+++ b/charts/jenkins-x/dex.yml
@@ -1,2 +1,2 @@
-version: 2.13.4
+version: 2.13.5
 gitUrl: https://github.com/jenkins-x/dex

--- a/charts/jenkins-x/jenkins-x-platform.yml
+++ b/charts/jenkins-x/jenkins-x-platform.yml
@@ -1,2 +1,2 @@
-version: 0.0.3487
+version: 0.0.3490
 gitUrl: https://github.com/jenkins-x/jenkins-x-platform

--- a/charts/jenkins-x/jx-build-templates.yml
+++ b/charts/jenkins-x/jx-build-templates.yml
@@ -1,2 +1,2 @@
-version: 0.0.389
+version: 0.0.447
 gitUrl: https://github.com/jenkins-x-charts/jx-build-templates

--- a/charts/jenkins-x/prow.yml
+++ b/charts/jenkins-x/prow.yml
@@ -1,2 +1,2 @@
-version: 0.0.314
+version: 0.0.316
 gitUrl: https://github.com/jenkins-x-charts/prow

--- a/charts/jenkins-x/sso-operator.yml
+++ b/charts/jenkins-x/sso-operator.yml
@@ -1,2 +1,2 @@
-version: 1.2.7
+version: 1.2.10
 gitUrl: https://github.com/jenkins-x/sso-operator


### PR DESCRIPTION
change `jenkins-x/dex` to version `2.13.5`
change `jenkins-x/jenkins-x-platform` to version `0.0.3490`
change `jenkins-x/jx-build-templates` to version `0.0.447`
change `jenkins-x/prow` to version `0.0.316`
change `jenkins-x/sso-operator` to version `1.2.10`
