### PR TITLE
upgrade chart versions

### DIFF
--- a/charts/jenkins-x/dex.yml
+++ b/charts/jenkins-x/dex.yml
@@ -1,2 +1,2 @@
-version: 2.13.5
+version: 2.13.7
 gitUrl: https://github.com/jenkins-x/dex

--- a/charts/jenkins-x/jenkins-x-platform.yml
+++ b/charts/jenkins-x/jenkins-x-platform.yml
@@ -1,2 +1,2 @@
-version: 0.0.3499
+version: 0.0.3513
 gitUrl: https://github.com/jenkins-x/jenkins-x-platform

--- a/charts/jenkins-x/jx-build-templates.yml
+++ b/charts/jenkins-x/jx-build-templates.yml
@@ -1,2 +1,2 @@
-version: 0.0.449
+version: 0.0.453
 gitUrl: https://github.com/jenkins-x-charts/jx-build-templates

--- a/charts/jenkins-x/prow.yml
+++ b/charts/jenkins-x/prow.yml
@@ -1,2 +1,2 @@
-version: 0.0.323
+version: 0.0.335
 gitUrl: https://github.com/jenkins-x-charts/prow

--- a/charts/jenkins-x/tekton.yml
+++ b/charts/jenkins-x/tekton.yml
@@ -1,2 +1,2 @@
-version: 0.0.29
+version: 0.0.30
 gitUrl: https://github.com/jenkins-x-charts/tekton


### PR DESCRIPTION
change `jenkins-x/dex` to version `2.13.7`
change `jenkins-x/jenkins-x-platform` to version `0.0.3513`
change `jenkins-x/jx-build-templates` to version `0.0.453`
change `jenkins-x/prow` to version `0.0.335`
change `jenkins-x/tekton` to version `0.0.30`
