### PR TITLE
upgrade dex to 2.13.9

### DIFF
--- a/charts/jenkins-x/dex.yml
+++ b/charts/jenkins-x/dex.yml
@@ -1,2 +1,2 @@
-version: 2.13.7
+version: 2.13.8
 gitUrl: https://github.com/jenkins-x/dex

--- a/charts/jenkins-x/dex.yml
+++ b/charts/jenkins-x/dex.yml
@@ -1,2 +1,2 @@
-version: 2.13.8
+version: 2.13.9
 gitUrl: https://github.com/jenkins-x/dex


### PR DESCRIPTION
upgrade `dex` from `2.13.7` to `2.13.9`

[upstream changes](https://github.com/jenkins-x/dex/compare/v2.13.7...jenkins-x:v2.13.9) (using github logins rather than user IDs)