### PR TITLE
delete stable manifest for external-dns

### DIFF
--- a/charts/stable/external-dns.yml
+++ b/charts/stable/external-dns.yml
@@ -1,2 +1,0 @@
-version: 1.5.2
-gitUrl: https://github.com/bitnami/charts/tree/master/bitnami/external-dns


### PR DESCRIPTION
was created in the incorrect location