### PR TITLE
upgrade chart versions

### DIFF
--- a/charts/jenkins-x/jenkins-x-platform.yml
+++ b/charts/jenkins-x/jenkins-x-platform.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jenkins-x-platform
-version: 0.0.3871
+version: 0.0.3877

--- a/charts/jenkins-x/jenkins-x-platform.yml
+++ b/charts/jenkins-x/jenkins-x-platform.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jenkins-x-platform
-version: 0.0.3832
+version: 0.0.3871

--- a/charts/jenkins-x/jx-build-templates.yml
+++ b/charts/jenkins-x/jx-build-templates.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/jx-build-templates
-version: 0.0.566
+version: 0.0.569

--- a/charts/jenkins-x/prow.yml
+++ b/charts/jenkins-x/prow.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/prow
-version: 0.0.470
+version: 0.0.494

--- a/charts/jenkins-x/tekton.yml
+++ b/charts/jenkins-x/tekton.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/tekton
-version: 0.0.33
+version: 0.0.34


### PR DESCRIPTION
change `jenkins-x/jenkins-x-platform` to version `0.0.3871`
change `jenkins-x/jx-build-templates` to version `0.0.569`
change `jenkins-x/prow` to version `0.0.494`
change `jenkins-x/tekton` to version `0.0.34`
