### PR TITLE
Downgrade certmanager to 0.6.7

### DIFF
--- a/charts/stable/cert-manager.yml
+++ b/charts/stable/cert-manager.yml
@@ -1,2 +1,2 @@
-version: v0.7.0
+version: v0.6.7
 gitUrl: https://github.com/helm/charts/tree/master/stable/cert-manager


### PR DESCRIPTION
0.7.0 is not availalable in
https://kubernetes-charts.storage.googleapis.com/ which causes an
install failure when installing and saying "Yes" to enabling cluster
wide TLS.

The most recent version is 0.6.7 so just use that.

hopefully fixes a regression introduced in #236 