### PR TITLE
feat: remove application and repository when tests end successfully

### DIFF
--- a/jx/bdd/eksclassic/ci.sh
+++ b/jx/bdd/eksclassic/ci.sh
@@ -32,4 +32,16 @@ git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
 
-jx step bdd --use-revision --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/eksclassic/cluster.yaml --gopath /tmp --base-domain=jxbdd.beescloud.com --git-provider=ghe --git-provider-url=https://github.beescloud.com --git-username dev1 --git-api-token $GHE_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+jx step bdd \
+    --use-revision \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config jx/bdd/eksclassic/cluster.yaml \
+    --gopath /tmp \
+    --base-domain=jxbdd.beescloud.com \
+    --git-provider=ghe \
+    --git-provider-url=https://github.beescloud.com \
+    --git-username dev1 \
+    --git-api-token $GHE_CREDS_PSW \
+    --default-admin-password $JENKINS_CREDS_PSW \
+    --tests install \
+    --tests test-create-spring

--- a/jx/bdd/ekstekton/ci.sh
+++ b/jx/bdd/ekstekton/ci.sh
@@ -36,4 +36,15 @@ git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
 
-jx step bdd --use-revision --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/ekstekton/cluster.yaml --base-domain=jxbdd.beescloud.com --gopath /tmp --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+jx step bdd \
+    --use-revision \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config jx/bdd/ekstekton/cluster.yaml \
+    --base-domain=jxbdd.beescloud.com \
+    --gopath /tmp \
+    --git-provider=github \
+    --git-username $GH_USERNAME \
+    --git-owner $GH_OWNER \
+    --git-api-token $GH_CREDS_PSW \
+    --tests install \
+    --tests test-create-spring

--- a/jx/bdd/gitops/ci.sh
+++ b/jx/bdd/gitops/ci.sh
@@ -28,4 +28,16 @@ git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
 
-jx step bdd --use-revision --version-repo-pr --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/gitops/cluster.yaml --gopath /tmp --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+jx step bdd \
+    --use-revision \
+    --version-repo-pr \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config jx/bdd/gitops/cluster.yaml \
+    --gopath /tmp \
+    --git-provider=github \
+    --git-username $GH_USERNAME \
+    --git-owner $GH_OWNER \
+    --git-api-token $GH_CREDS_PSW \
+    --default-admin-password $JENKINS_CREDS_PSW \
+    --tests install \
+    --tests test-create-spring

--- a/jx/bdd/helm3/ci.sh
+++ b/jx/bdd/helm3/ci.sh
@@ -42,8 +42,6 @@ jx step bdd \
     --git-owner $GH_OWNER \
     --git-api-token $GH_CREDS_PSW \
     --default-admin-password $JENKINS_CREDS_PSW \
-    --no-delete-app \
-    --no-delete-repo \
     --tests install \
     --tests test-verify-pods \
     --tests test-upgrade-platform \

--- a/jx/bdd/knative-build/ci.sh
+++ b/jx/bdd/knative-build/ci.sh
@@ -28,4 +28,16 @@ git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
 
-jx step bdd --use-revision  --version-repo-pr --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/knative-build/cluster.yaml --gopath /tmp --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+jx step bdd \
+    --use-revision  \
+    --version-repo-pr \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config jx/bdd/knative-build/cluster.yaml \
+    --gopath /tmp \
+    --git-provider=github \
+    --git-username $GH_USERNAME \
+    --git-owner $GH_OWNER \
+    --git-api-token $GH_CREDS_PSW \
+    --default-admin-password $JENKINS_CREDS_PSW \
+    --tests install \
+    --tests test-create-spring

--- a/jx/bdd/ng/ci.sh
+++ b/jx/bdd/ng/ci.sh
@@ -28,4 +28,16 @@ git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
 
-jx step bdd --use-revision  --version-repo-pr --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/ng/cluster.yaml --gopath /tmp --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+jx step bdd \
+    --use-revision \
+    --version-repo-pr \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config jx/bdd/ng/cluster.yaml \
+    --gopath /tmp \
+    --git-provider=github \
+    --git-username $GH_USERNAME \
+    --git-owner $GH_OWNER \
+    --git-api-token $GH_CREDS_PSW \
+    --default-admin-password $JENKINS_CREDS_PSW \
+    --tests install \
+    --tests test-create-spring

--- a/jx/bdd/static-gke-us-east1-b/ci.sh
+++ b/jx/bdd/static-gke-us-east1-b/ci.sh
@@ -30,4 +30,16 @@ git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
 
-jx step bdd --use-revision  --version-repo-pr --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/static-gke-us-east1-b/cluster.yaml --gopath /tmp --git-provider=ghe --git-provider-url=https://github.beescloud.com --git-username dev1 --git-api-token $GHE_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+jx step bdd \
+    --use-revision \
+    --version-repo-pr \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config jx/bdd/static-gke-us-east1-b/cluster.yaml \
+    --gopath /tmp \
+    --git-provider=ghe \
+    --git-provider-url=https://github.beescloud.com \
+    --git-username dev1 \
+    --git-api-token $GHE_CREDS_PSW \
+    --default-admin-password $JENKINS_CREDS_PSW \
+    --tests install \
+    --tests test-create-spring

--- a/jx/bdd/static/ci.sh
+++ b/jx/bdd/static/ci.sh
@@ -30,4 +30,16 @@ git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
 
-jx step bdd --use-revision  --version-repo-pr --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/static/cluster.yaml --gopath /tmp --git-provider=ghe --git-provider-url=https://github.beescloud.com --git-username dev1 --git-api-token $GHE_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+jx step bdd \
+    --use-revision \
+    --version-repo-pr \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config jx/bdd/static/cluster.yaml \
+    --gopath /tmp \
+    --git-provider=ghe \
+    --git-provider-url=https://github.beescloud.com \
+    --git-username dev1 \
+    --git-api-token $GHE_CREDS_PSW \
+    --default-admin-password $JENKINS_CREDS_PSW \
+    --tests install \
+    --tests test-create-spring

--- a/jx/bdd/tekton/ci.sh
+++ b/jx/bdd/tekton/ci.sh
@@ -42,8 +42,6 @@ jx step bdd \
     --git-owner $GH_OWNER \
     --git-api-token $GH_CREDS_PSW \
     --default-admin-password $JENKINS_CREDS_PSW \
-    --no-delete-app \
-    --no-delete-repo \
     --tests install \
     --tests test-verify-pods \
     --tests test-upgrade-platform \

--- a/jx/bdd/terraform/ci.sh
+++ b/jx/bdd/terraform/ci.sh
@@ -42,8 +42,6 @@ jx step bdd \
     --git-owner $GH_OWNER \
     --git-api-token $GH_CREDS_PSW \
     --default-admin-password $JENKINS_CREDS_PSW \
-    --no-delete-app \
-    --no-delete-repo \
     --tests install \
     --tests test-verify-pods \
     --tests test-upgrade-platform \

--- a/jx/bdd/tiller/ci.sh
+++ b/jx/bdd/tiller/ci.sh
@@ -30,4 +30,16 @@ git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
 
-jx step bdd --use-revision  --version-repo-pr --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git --config jx/bdd/tiller/cluster.yaml --gopath /tmp --git-provider=ghe --git-provider-url=https://github.beescloud.com --git-username dev1 --git-api-token $GHE_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+jx step bdd \
+    --use-revision \
+    --version-repo-pr \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config jx/bdd/tiller/cluster.yaml \
+    --gopath /tmp \
+    --git-provider=ghe \
+    --git-provider-url=https://github.beescloud.com \
+    --git-username dev1 \
+    --git-api-token $GHE_CREDS_PSW \
+    --default-admin-password $JENKINS_CREDS_PSW \
+    --tests install \
+    --tests test-create-spring

--- a/jx/scripts/ci-github.sh
+++ b/jx/scripts/ci-github.sh
@@ -36,4 +36,12 @@ git clone https://github.com/jenkins-x/jenkins-x-versions.git
 popd
 cp -r * ~/.jx/jenkins-x-versions
 
-jx step bdd --dir . --config jx/bdd/staticjenkins.yaml --gopath /tmp --git-provider=github --git-username $GH_USERNAME --git-owner $GH_OWNER --git-api-token $GH_CREDS_PSW --default-admin-password $JENKINS_CREDS_PSW --no-delete-app --no-delete-repo --tests install --tests test-create-spring
+jx step bdd --dir . --config jx/bdd/staticjenkins.yaml \
+    --gopath /tmp \
+    --git-provider=github \
+    --git-username $GH_USERNAME \
+    --git-owner $GH_OWNER \
+    --git-api-token $GH_CREDS_PSW \
+    --default-admin-password $JENKINS_CREDS_PSW \
+    --tests install \
+    --tests test-create-spring


### PR DESCRIPTION
The flags `--no-delete-app` and `--no-delete-repo` have been removed so that the application created for the tests and its repository are deleted when the tests finish.

If tests fail, the delete application / repository logic won't be executed so that we can take a look.