### PR TITLE
chore: Add upper limit to helm version

### DIFF
--- a/packages/helm.yml
+++ b/packages/helm.yml
@@ -1,3 +1,4 @@
 version: 2.12.2
+upperLimit: 3.0.0
 gitUrl: https://github.com/helm/helm
 url: https://helm.sh/


### PR DESCRIPTION
Add an upper limit of 3.0.0 to helm version