### PR TITLE
fix: update to new nginx chart 1.10.3

### DIFF
--- a/charts/stable/nginx-ingress.yml
+++ b/charts/stable/nginx-ingress.yml
@@ -1,2 +1,2 @@
-version: 1.3.1
+version: 1.10.3
 gitUrl: https://github.com/helm/charts/tree/master/stable/nginx-ingress


### PR DESCRIPTION
This avoids the bug with the `clusterIP` getting updated during `jx boot`