### PR TITLE
chore: Add resource requests/limits and GOPROXY.

### DIFF
--- a/jenkins-x-boot-lh-bs.yml
+++ b/jenkins-x-boot-lh-bs.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-boot-lh-ghe.yml
+++ b/jenkins-x-boot-lh-ghe.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-boot-lh.yml
+++ b/jenkins-x-boot-lh.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-boot-local.yml
+++ b/jenkins-x-boot-local.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-boot-vault.yml
+++ b/jenkins-x-boot-vault.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-eksclassic.yml
+++ b/jenkins-x-eksclassic.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-ekstekton.yml
+++ b/jenkins-x-ekstekton.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-gitops.yml
+++ b/jenkins-x-gitops.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-helm3.yml
+++ b/jenkins-x-helm3.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-ng.yml
+++ b/jenkins-x-ng.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-prow.yml
+++ b/jenkins-x-prow.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-static-gke-us-east1-b.yml
+++ b/jenkins-x-static-gke-us-east1-b.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-static.yml
+++ b/jenkins-x-static.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:

--- a/jenkins-x-terraform.yml
+++ b/jenkins-x-terraform.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-terraform:0.1.615
         stages:

--- a/jenkins-x-tiller.yml
+++ b/jenkins-x-tiller.yml
@@ -3,6 +3,18 @@ pipelineConfig:
   pipelines:
     pullRequest:
       pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
         agent:
           image: gcr.io/jenkinsxio/builder-go-maven:0.1.615
         stages:


### PR DESCRIPTION
I've noticed that these builds can cause problems with CPU usage on
nodes, since they had no request or limit, and that they're slower
fetching the go dependencies to build the BDD tests. So let's add
those things.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>