### PR TITLE
fix: remove the use of the classic git buildpack

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -1,5 +1,4 @@
-buildPack: git
-buildPackGitURL: https://github.com/jenkins-x-buildpacks/jenkins-x-classic.git
+buildPack: none
 pipelineConfig:
   pipelines:
     release:


### PR DESCRIPTION
Since the addition of the extra step in this pipeline the git buildpack seems to be ignored. In addition the default behaviour for the `release` step in a `jenkins-x` pipeline is to tag the repository with the next version.