### PR TITLE
chore(deps): bump  versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -27,3 +27,4 @@ Dependency | Sources | Version | Mismatched versions
 [weaveworks/flagger](https://github.com/weaveworks/flagger):grafana |  | [1.3.0]() | 
 [jenkins-x-charts/prow](https://github.com/jenkins-x-charts/prow):knative |  | []() | 
 [jenkins-x/jenkins-x-boot-config](https://github.com/jenkins-x/jenkins-x-boot-config) |  | [1.0.1](https://github.com/jenkins-x/jenkins-x-boot-config/releases/tag/v1.0.1) | 
+[jenkins-x-buildpacks/jenkins-x-kubernetes](https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes) |  | [1.0.0](https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes/releases/tag/v1.0.0) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -26,3 +26,4 @@ Dependency | Sources | Version | Mismatched versions
 [weaveworks/flagger](https://github.com/weaveworks/flagger):flagger |  | [0.18.2](https://github.com/weaveworks/flagger/releases/tag/0.18.2) | 
 [weaveworks/flagger](https://github.com/weaveworks/flagger):grafana |  | [1.3.0]() | 
 [jenkins-x-charts/prow](https://github.com/jenkins-x-charts/prow):knative |  | []() | 
+[jenkins-x/jenkins-x-boot-config](https://github.com/jenkins-x/jenkins-x-boot-config) |  | [1.0.1](https://github.com/jenkins-x/jenkins-x-boot-config/releases/tag/v1.0.1) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -180,3 +180,9 @@ dependencies:
   url: https://github.com/jenkins-x/jenkins-x-boot-config
   version: 1.0.1
   versionURL: https://github.com/jenkins-x/jenkins-x-boot-config/releases/tag/v1.0.1
+- host: github.com
+  owner: jenkins-x-buildpacks
+  repo: jenkins-x-kubernetes
+  url: https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes
+  version: 1.0.0
+  versionURL: https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes/releases/tag/v1.0.0

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -174,3 +174,9 @@ dependencies:
   url: https://github.com/jenkins-x-charts/prow
   version: ""
   versionURL: ""
+- host: github.com
+  owner: jenkins-x
+  repo: jenkins-x-boot-config
+  url: https://github.com/jenkins-x/jenkins-x-boot-config
+  version: 1.0.1
+  versionURL: https://github.com/jenkins-x/jenkins-x-boot-config/releases/tag/v1.0.1

--- a/git/github.com/jenkins-x-buildpacks/jenkins-x-classic.yml
+++ b/git/github.com/jenkins-x-buildpacks/jenkins-x-classic.yml
@@ -1,2 +1,2 @@
 version: 1.0.0
-giUrl: https://github.com/jenkins-x-buildpacks/jenkins-x-classic
+gitUrl: https://github.com/jenkins-x-buildpacks/jenkins-x-classic

--- a/git/github.com/jenkins-x-buildpacks/jenkins-x-kubernetes.yml
+++ b/git/github.com/jenkins-x-buildpacks/jenkins-x-kubernetes.yml
@@ -1,1 +1,2 @@
-version: 1.0.0
+version: master
+gitUrl: https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes

--- a/git/github.com/jenkins-x-buildpacks/jenkins-x-kubernetes.yml
+++ b/git/github.com/jenkins-x-buildpacks/jenkins-x-kubernetes.yml
@@ -1,2 +1,1 @@
-version: master
-giUrl: https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes
+version: 1.0.0

--- a/git/github.com/jenkins-x-buildpacks/jenkins-x-kubernetes.yml
+++ b/git/github.com/jenkins-x-buildpacks/jenkins-x-kubernetes.yml
@@ -1,2 +1,2 @@
-version: master
 gitUrl: https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes
+version: 1.0.0

--- a/git/github.com/jenkins-x/jenkins-x-boot-config.yml
+++ b/git/github.com/jenkins-x/jenkins-x-boot-config.yml
@@ -1,2 +1,2 @@
-version: 1.0.0
 gitUrl: https://github.com/jenkins-x/jenkins-x-boot-config
+version: 1.0.1

--- a/git/github.com/jenkins-x/jenkins-x-boot-config.yml
+++ b/git/github.com/jenkins-x/jenkins-x-boot-config.yml
@@ -1,2 +1,1 @@
-version: 1.0.0
-giUrl: https://github.com/jenkins-x/jenkins-x-boot-config
+version: 1.0.1

--- a/git/github.com/jenkins-x/jenkins-x-boot-config.yml
+++ b/git/github.com/jenkins-x/jenkins-x-boot-config.yml
@@ -1,1 +1,2 @@
-version: 1.0.1
+version: 1.0.0
+gitUrl: https://github.com/jenkins-x/jenkins-x-boot-config


### PR DESCRIPTION
Update  versions

Command run was `jx step create pr versions -f * --excludes jetstack/cert-manager --kind git`
<hr />

Update  versions

Command run was `jx step create pr versions --filter=* --images --excludes=jetstack/cert-manager --batch-mode`
<hr />

Update  versions

Command run was `jx step create pr versions --filter=\"*\" --images --excludes='jetstack/cert-manager' --batch-mode`
<hr />

Update  versions

Command run was `jx step create pr versions --filter=\"*\" --images --excludes='jetstack/cert-manager' --batch-mode`
<hr />

Update  versions

Command run was `jx step create pr versions --filter=\"*\" --images --excludes='jetstack/cert-manager' --batch-mode`
<hr />

Update  versions

Command run was `jx step create pr versions -f * --excludes jetstack/cert-manager --kind git`