### PR TITLE
feat: release jx version on merge to master - step 1

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -7,6 +7,9 @@ pipelineConfig:
           image: gcr.io/jenkinsxio/builder-jx:0.1.610
         stages:
           - name: changelog
+            environment:
+              - name: JX_VERSION
+                value: $(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" dependency-matrix/matrix.md)
             steps:
               - name: changelog
                 command: jx
@@ -18,3 +21,6 @@ pipelineConfig:
                 - ${VERSION}
                 - --rev
                 - ${PULL_BASE_SHA}
+
+              - name: release-jx
+                command: ./jx/scripts/release-jx.sh

--- a/jx/scripts/release-jx.sh
+++ b/jx/scripts/release-jx.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+export GH_OWNER="jenkins-x"
+export GH_REPO="jx"
+
+if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
+then
+  jx step update release-status github --owner $GH_OWNER --repository $GH_REPO --version $JX_VERSION --prerelease=false
+fi


### PR DESCRIPTION
This change is part of a multi-step approach to gating the release of the `jx` client. 

1. The environment variable `JX_VERSION` tries to retrieve the tested `jx` client version from the dependency matrix.
2. The `release-jx.sh` script sets the `jx` release status of `JX_VERSION` release to `released` (_n.b. it updates the release record with prerelease=false_) - this is a noop command should the release record not be marked as a prerelease.


Signed-off-by: Cai Cooper <caicooper82@gmail.com>