### PR TITLE
chore: Remove create-spring from tekton bdd tests

### DIFF
--- a/jx/bdd/tekton/ci.sh
+++ b/jx/bdd/tekton/ci.sh
@@ -49,6 +49,5 @@ jx step bdd \
     --tests test-upgrade-platform \
     --tests test-upgrade-ingress \
     --tests test-app-lifecycle \
-    --tests test-create-spring \
     --tests test-quickstart-golang-http \
     --tests test-import


### PR DESCRIPTION
It's redundant - `ng` runs `create-spring` in the same scenario, and
the `tekton` context is already taking over an hour. Let's cut that
time down a bit.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>