### PR TITLE
fix: moved JX_VERSION env var to release-jx script

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -7,9 +7,6 @@ pipelineConfig:
           image: gcr.io/jenkinsxio/builder-jx:0.1.610
         stages:
           - name: changelog
-            environment:
-              - name: JX_VERSION
-                value: $(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" dependency-matrix/matrix.md)
             steps:
               - name: changelog
                 command: jx

--- a/jx/scripts/release-jx.sh
+++ b/jx/scripts/release-jx.sh
@@ -4,6 +4,7 @@ set -x
 
 export GH_OWNER="jenkins-x"
 export GH_REPO="jx"
+export JX_VERSION=$(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" ../../dependency-matrix/matrix.md)
 
 if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
 then


### PR DESCRIPTION
Signed-off-by: Cai Cooper <caicooper82@gmail.com>

It seems that pipeline environment variables do not execute commands in `$()`, as a result the JX_VERSION environment variable has been moved into `jx/scripts/release-jx.sh` script.