### PR TITLE
fix: Only publish when jx is prerelease

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -24,7 +24,12 @@ pipelineConfig:
                 value: -Xmx4g
               - name: _JAVA_OPTIONS
                 value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms1G -Xmx4G
+              - name: IS_JX_PRERELEASE
+                value: /repo/is_jx_prerelease
             steps:
+              - name: get-jx-prerelease-state
+                command: ./jx/scripts/get-jx-prerelease-state.sh
+
               - name: changelog
                 command: jx
                 args:

--- a/jx/scripts/get-jx-prerelease-state.sh
+++ b/jx/scripts/get-jx-prerelease-state.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+JX_RELEASES_URL="https://api.github.com/repos/jenkins-x/jx/releases/tags"
+JX_VERSION=$(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" ./dependency-matrix/matrix.md)
+
+if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
+then
+  mkdir -p /repo
+  curl -s ${JX_RELEASES_URL}/v${JX_VERSION} | jq -r '.prerelease' > ${IS_JX_PRERELEASE}
+fi
+

--- a/jx/scripts/update-jx-bot.sh
+++ b/jx/scripts/update-jx-bot.sh
@@ -4,18 +4,21 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-JX_VERSION=$(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" ./dependency-matrix/matrix.md)
-
-if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
+if $(cat ${IS_JX_PRERELEASE})
 then
-  CHECKSUMS="https://github.com/jenkins-x/jx/releases/download/v${JX_VERSION}/jx-checksums.txt"
-  SHA256=$(curl -Ls ${CHECKSUMS} | grep 'darwin' | cut -d' ' -f1)
-  if [ ! -z $SHA256 ]
+  JX_VERSION=$(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" ./dependency-matrix/matrix.md)
+
+  if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
   then
-    jx step create pr brew --version $JX_VERSION --sha $SHA256 --repo https://github.com/jenkins-x/homebrew-jx.git --src-repo https://github.com/jenkins-x/jx.git
+    CHECKSUMS="https://github.com/jenkins-x/jx/releases/download/v${JX_VERSION}/jx-checksums.txt"
+    SHA256=$(curl -Ls ${CHECKSUMS} | grep 'darwin' | cut -d' ' -f1)
+    if [ ! -z $SHA256 ]
+    then
+      jx step create pr brew --version $JX_VERSION --sha $SHA256 --repo https://github.com/jenkins-x/homebrew-jx.git --src-repo https://github.com/jenkins-x/jx.git
+    fi
+    jx step create pr docker --name JX_VERSION --version $JX_VERSION --repo https://github.com/jenkins-x/dev-env-base.git
+    jx step create pr regex --regex "\s*release = \"(.*)\"" --version $JX_VERSION --files config.toml --repo https://github.com/jenkins-x/jx-docs.git
+    jx step create pr regex --regex "JX_VERSION=(.*)" --version $JX_VERSION --files install-jx.sh --repo https://github.com/jenkins-x/jx-tutorial.git
   fi
-  jx step create pr docker --name JX_VERSION --version $JX_VERSION --repo https://github.com/jenkins-x/dev-env-base.git
-  jx step create pr regex --regex "\s*release = \"(.*)\"" --version $JX_VERSION --files config.toml --repo https://github.com/jenkins-x/jx-docs.git
-  jx step create pr regex --regex "JX_VERSION=(.*)" --version $JX_VERSION --files install-jx.sh --repo https://github.com/jenkins-x/jx-tutorial.git
 fi
 

--- a/jx/scripts/update-jx-clients.sh
+++ b/jx/scripts/update-jx-clients.sh
@@ -1,39 +1,42 @@
 #!/usr/bin/env bash
 
-ORG_REPOS=("jenkins-x/jx-ts-client")
-JX_VERSION=$(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" ./dependency-matrix/matrix.md)
-
-if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
+if $(cat ${IS_JX_PRERELEASE})
 then
-  pushd $(mktemp -d)
-    git clone https://github.com/jenkins-x/jx.git
-    pushd jx
-      git fetch --tags
-      git checkout v${JX_VERSION}
-      pushd docs/apidocs/openapi-spec
-        SRCDIR=`pwd`
+  ORG_REPOS=("jenkins-x/jx-ts-client")
+  JX_VERSION=$(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" ./dependency-matrix/matrix.md)
+
+  if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
+  then
+    pushd $(mktemp -d)
+      git clone https://github.com/jenkins-x/jx.git
+      pushd jx
+        git fetch --tags
+        git checkout v${JX_VERSION}
+        pushd docs/apidocs/openapi-spec
+          SRCDIR=`pwd`
+        popd
       popd
     popd
-  popd
-  SRC="${SRCDIR}/openapiv2.yaml"
-  for org_repo in "${ORG_REPOS[@]}"; do
-    OUTDIR="$(jx step git fork-and-clone -b --print-out-dir --dir=$TMPDIR https://github.com/$org_repo)"
-    echo "Forked repo to $OUTDIR"
-    pushd $OUTDIR
-      echo "Running make all in $org_repo"
-      make all
-      echo "make all complete in $org_repo"
-      git add -N .
-      git diff --exit-code
-      if [ $? -ne 0 ]
-      then
-        set -x
-        jx create pullrequest -b --push=true --fork=true --body "upgrade $org_repo client to jx $JX_VERSION" --title "upgrade to jx $JX_VERSION" --label="updatebot"
-        set +x
-      else
-        echo "No changes to generated code"
-      fi
-    popd
-  done
+    SRC="${SRCDIR}/openapiv2.yaml"
+    for org_repo in "${ORG_REPOS[@]}"; do
+      OUTDIR="$(jx step git fork-and-clone -b --print-out-dir --dir=$TMPDIR https://github.com/$org_repo)"
+      echo "Forked repo to $OUTDIR"
+      pushd $OUTDIR
+        echo "Running make all in $org_repo"
+        make all
+        echo "make all complete in $org_repo"
+        git add -N .
+        git diff --exit-code
+        if [ $? -ne 0 ]
+        then
+          set -x
+          jx create pullrequest -b --push=true --fork=true --body "upgrade $org_repo client to jx $JX_VERSION" --title "upgrade to jx $JX_VERSION" --label="updatebot"
+          set +x
+        else
+          echo "No changes to generated code"
+        fi
+      popd
+    done
+  fi
 fi
 exit 0

--- a/jx/scripts/update-jx-clients.sh
+++ b/jx/scripts/update-jx-clients.sh
@@ -5,15 +5,14 @@ JX_VERSION=$(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" ./dependency-m
 
 if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
 then
-  if [ ! -d ./jx ]
-  then
+  pushd $(mktemp -d)
     git clone https://github.com/jenkins-x/jx.git
-  fi
-  pushd jx
-    git fetch --tags
-    git checkout v${JX_VERSION}
-    pushd docs/apidocs/openapi-spec
-      SRCDIR=`pwd`
+    pushd jx
+      git fetch --tags
+      git checkout v${JX_VERSION}
+      pushd docs/apidocs/openapi-spec
+        SRCDIR=`pwd`
+      popd
     popd
   popd
   SRC="${SRCDIR}/openapiv2.yaml"

--- a/jx/scripts/update-jx-website.sh
+++ b/jx/scripts/update-jx-website.sh
@@ -4,50 +4,53 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-JX_VERSION=$(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" ./dependency-matrix/matrix.md)
-
-if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
+if $(cat ${IS_JX_PRERELEASE})
 then
-  echo "updating the CLI reference"
+  JX_VERSION=$(sed "s:^.*jenkins-x\/jx.*\[\([0-9.]*\)\].*$:\1:;t;d" ./dependency-matrix/matrix.md)
 
-  pushd $(mktemp -d)
-    git clone https://github.com/jenkins-x/jx-docs.git
-    pushd jx-docs/content/en/docs/reference/commands
-      jx create docs
-      git config credential.helper store
-      git add *
-      git commit --allow-empty -a -m "updated jx commands & API docs from $JX_VERSION"
-      git fetch origin && git rebase origin/master
+  if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
+  then
+    echo "updating the CLI reference"
+
+    pushd $(mktemp -d)
+      git clone https://github.com/jenkins-x/jx-docs.git
+      pushd jx-docs/content/en/docs/reference/commands
+        jx create docs
+        git config credential.helper store
+        git add *
+        git commit --allow-empty -a -m "updated jx commands & API docs from $JX_VERSION"
+        git fetch origin && git rebase origin/master
+      popd
+
+      echo "Updating the JSON Schema"
+      pushd jx-docs/content
+        mkdir -p schemas
+        cd schemas
+        jx step syntax schema -o jx-schema.json
+        git add *
+        git commit --allow-empty -a -m "updated jx Json Schema from $JX_VERSION"
+        git fetch origin && git rebase origin/master
+      popd
+
+      echo "Updating the JX CLI & API reference docs"
+
+      git clone https://github.com/jenkins-x/jx.git
+      pushd jx
+        git fetch --tags
+        git checkout v${JX_VERSION}
+        make generate-docs
+      popd
+      cp -r jx/docs/apidocs/site ../jx-docs/static/apidocs
+
+      pushd jx-docs/static/apidocs
+        git add *
+        git commit --allow-empty -a -m "updated jx API docs from $JX_VERSION"
+        git fetch origin && git rebase origin/master
+      popd
+
+      pushd jx-docs
+        git push origin
+      popd
     popd
-
-    echo "Updating the JSON Schema"
-    pushd jx-docs/content
-      mkdir -p schemas
-      cd schemas
-      jx step syntax schema -o jx-schema.json
-      git add *
-      git commit --allow-empty -a -m "updated jx Json Schema from $JX_VERSION"
-      git fetch origin && git rebase origin/master
-    popd
-
-    echo "Updating the JX CLI & API reference docs"
-
-    git clone https://github.com/jenkins-x/jx.git
-    pushd jx
-      git fetch --tags
-      git checkout v${JX_VERSION}
-      make generate-docs
-    popd
-    cp -r jx/docs/apidocs/site ../jx-docs/static/apidocs
-
-    pushd jx-docs/static/apidocs
-      git add *
-      git commit --allow-empty -a -m "updated jx API docs from $JX_VERSION"
-      git fetch origin && git rebase origin/master
-    popd
-
-    pushd jx-docs
-      git push origin
-    popd
-  popd
+  fi
 fi

--- a/jx/scripts/update-jx-website.sh
+++ b/jx/scripts/update-jx-website.sh
@@ -10,48 +10,44 @@ if [[ $JX_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*$ ]]
 then
   echo "updating the CLI reference"
 
-  if [ ! -d ./jx-docs ]
-  then
+  pushd $(mktemp -d)
     git clone https://github.com/jenkins-x/jx-docs.git
-  fi
-  pushd jx-docs/content/en/docs/reference/commands
-    jx create docs
-    git config credential.helper store
-    git add *
-    git commit --allow-empty -a -m "updated jx commands & API docs from $JX_VERSION"
-    git fetch origin && git rebase origin/master
-  popd
+    pushd jx-docs/content/en/docs/reference/commands
+      jx create docs
+      git config credential.helper store
+      git add *
+      git commit --allow-empty -a -m "updated jx commands & API docs from $JX_VERSION"
+      git fetch origin && git rebase origin/master
+    popd
 
-  echo "Updating the JSON Schema"
-  pushd jx-docs/content
-    mkdir -p schemas
-    cd schemas
-    jx step syntax schema -o jx-schema.json
-    git add *
-    git commit --allow-empty -a -m "updated jx Json Schema from $JX_VERSION"
-    git fetch origin && git rebase origin/master
-  popd
+    echo "Updating the JSON Schema"
+    pushd jx-docs/content
+      mkdir -p schemas
+      cd schemas
+      jx step syntax schema -o jx-schema.json
+      git add *
+      git commit --allow-empty -a -m "updated jx Json Schema from $JX_VERSION"
+      git fetch origin && git rebase origin/master
+    popd
 
-  echo "Updating the JX CLI & API reference docs"
+    echo "Updating the JX CLI & API reference docs"
 
-  if [ ! -d ./jx ]
-  then
     git clone https://github.com/jenkins-x/jx.git
-  fi
-  pushd jx
-    git fetch --tags
-    git checkout v${JX_VERSION}
-    make generate-docs
-  popd
-  cp -r jx/docs/apidocs/site ../jx-docs/static/apidocs
+    pushd jx
+      git fetch --tags
+      git checkout v${JX_VERSION}
+      make generate-docs
+    popd
+    cp -r jx/docs/apidocs/site ../jx-docs/static/apidocs
 
-  pushd jx-docs/static/apidocs
-    git add *
-    git commit --allow-empty -a -m "updated jx API docs from $JX_VERSION"
-    git fetch origin && git rebase origin/master
-  popd
+    pushd jx-docs/static/apidocs
+      git add *
+      git commit --allow-empty -a -m "updated jx API docs from $JX_VERSION"
+      git fetch origin && git rebase origin/master
+    popd
 
-   pushd jx-docs
-    git push origin
+    pushd jx-docs
+      git push origin
+    popd
   popd
 fi


### PR DESCRIPTION
### Summary
This change prevents the downstream components from being updated if the state of the `jx` release is not a prerelease.