### PR TITLE
fix: turn off in-cluster discovery of vault URL in `boot-vault`

### DIFF
--- a/jx/bdd/boot-vault/jx-requirements.yml
+++ b/jx/bdd/boot-vault/jx-requirements.yml
@@ -30,5 +30,7 @@ storage:
   reports:
     enabled: true
     url: "gs://jx-bdd-log-store3"
+vault:
+  disableURLDiscovery: true
 webhook: prow
 


### PR DESCRIPTION
`boot-vault` will fail until https://github.com/jenkins-x/jx/pull/5613
is merged/in the builders we're testing, but hey. =)

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>