### PR TITLE
fix: Add app lifecycle tests to boot-[vault,vault-tls,local] contexts

### DIFF
--- a/jx/bdd/boot-local/ci.sh
+++ b/jx/bdd/boot-local/ci.sh
@@ -62,4 +62,6 @@ jx step bdd \
     --no-delete-repo \
     --tests install \
     --tests test-create-spring \
-    --tests test-single-import
+    --tests test-single-import \
+    --tests test-app-lifecycle
+

--- a/jx/bdd/boot-local/jx-requirements.yml
+++ b/jx/bdd/boot-local/jx-requirements.yml
@@ -1,6 +1,6 @@
 cluster:
   clusterName: bdd-boot
-  environmentGitOwner: cb-kubecd
+  environmentGitOwner: jenkins-x-bot-test
   project: jenkins-x-bdd3
   provider: gke
   zone: europe-west1-c

--- a/jx/bdd/boot-vault-tls/ci.sh
+++ b/jx/bdd/boot-vault-tls/ci.sh
@@ -83,4 +83,5 @@ jx step bdd \
     --no-delete-app \
     --no-delete-repo \
     --tests install \
-    --tests test-create-spring
+    --tests test-create-spring \
+    --tests test-app-lifecycle

--- a/jx/bdd/boot-vault/ci.sh
+++ b/jx/bdd/boot-vault/ci.sh
@@ -62,4 +62,6 @@ jx step bdd \
     --no-delete-repo \
     --tests install \
     --tests test-create-spring \
-    --tests test-single-import
+    --tests test-single-import \
+    --tests test-app-lifecycle
+

--- a/jx/bdd/boot-vault/jx-requirements.yml
+++ b/jx/bdd/boot-vault/jx-requirements.yml
@@ -1,6 +1,6 @@
 cluster:
   clusterName: bdd-boot-v
-  environmentGitOwner: cb-kubecd
+  environmentGitOwner: jenkins-x-bot-test
   project: jenkins-x-bdd3
   provider: gke
   zone: europe-west1-c


### PR DESCRIPTION
We're running these on `tekton`, and on `boot-vault` on `jx`, but we
should be running them on some representative boot contexts here as
well, particularly `boot-local` and `boot-vault-tls`.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>