### PR TITLE
fix: Switch to new GitHub bot test user

### DIFF
--- a/jenkins-x-boot-jenkins.yml
+++ b/jenkins-x-boot-jenkins.yml
@@ -20,7 +20,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-boot-lh.yml
+++ b/jenkins-x-boot-lh.yml
@@ -20,7 +20,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-boot-local.yml
+++ b/jenkins-x-boot-local.yml
@@ -20,7 +20,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-boot-vault-tls.yml
+++ b/jenkins-x-boot-vault-tls.yml
@@ -30,7 +30,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-boot-vault.yml
+++ b/jenkins-x-boot-vault.yml
@@ -22,7 +22,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-ekstekton.yml
+++ b/jenkins-x-ekstekton.yml
@@ -20,7 +20,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-gitops.yml
+++ b/jenkins-x-gitops.yml
@@ -20,7 +20,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-helm3.yml
+++ b/jenkins-x-helm3.yml
@@ -20,7 +20,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-ng.yml
+++ b/jenkins-x-ng.yml
@@ -20,7 +20,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-prow.yml
+++ b/jenkins-x-prow.yml
@@ -20,7 +20,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -20,7 +20,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-terraform-static.yml
+++ b/jenkins-x-terraform-static.yml
@@ -9,7 +9,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jenkins-x-terraform-tekton.yml
+++ b/jenkins-x-terraform-tekton.yml
@@ -20,7 +20,7 @@ pipelineConfig:
           - name: GH_ACCESS_TOKEN 
             valueFrom:
               secretKeyRef:
-                name: jenkins-x-bot-test-github
+                name: jenkins-x-versions-bot-test-github
                 key: password
           - name: JENKINS_PASSWORD
             valueFrom:

--- a/jx/bdd/boot-jenkins/ci.sh
+++ b/jx/bdd/boot-jenkins/ci.sh
@@ -2,9 +2,9 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
 export GH_EMAIL="jenkins-x@googlegroups.com"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/boot-jenkins/parameters.yaml
+++ b/jx/bdd/boot-jenkins/parameters.yaml
@@ -6,5 +6,5 @@ gpg: {}
 pipelineUser:
   github:
     host: github.com
-    username: jenkins-x-bot-test
+    username: jenkins-x-versions-bot-test
     email: jenkins-x@googlegroups.com

--- a/jx/bdd/boot-lh/ci.sh
+++ b/jx/bdd/boot-lh/ci.sh
@@ -2,9 +2,9 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
 export GH_EMAIL="jenkins-x@googlegroups.com"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/boot-lh/parameters.yaml
+++ b/jx/bdd/boot-lh/parameters.yaml
@@ -6,5 +6,5 @@ gpg: {}
 pipelineUser:
   github:
     host: github.com
-    username: jenkins-x-bot-test
+    username: jenkins-x-versions-bot-test
     email: jenkins-x@googlegroups.com

--- a/jx/bdd/boot-local/ci.sh
+++ b/jx/bdd/boot-local/ci.sh
@@ -2,9 +2,9 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
 export GH_EMAIL="jenkins-x@googlegroups.com"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/boot-local/jx-requirements.yml
+++ b/jx/bdd/boot-local/jx-requirements.yml
@@ -1,6 +1,6 @@
 cluster:
   clusterName: bdd-boot
-  environmentGitOwner: jenkins-x-bot-test
+  environmentGitOwner: jenkins-x-versions-bot-test
   project: jenkins-x-bdd3
   provider: gke
   zone: europe-west1-c

--- a/jx/bdd/boot-local/parameters.yaml
+++ b/jx/bdd/boot-local/parameters.yaml
@@ -6,5 +6,5 @@ gpg: {}
 pipelineUser:
   github:
     host: github.com
-    username: jenkins-x-bot-test
+    username: jenkins-x-versions-bot-test
     email: jenkins-x@googlegroups.com

--- a/jx/bdd/boot-vault-tls/ci.sh
+++ b/jx/bdd/boot-vault-tls/ci.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
 export GH_EMAIL="jenkins-x@googlegroups.com"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/boot-vault-tls/jx-requirements.yml
+++ b/jx/bdd/boot-vault-tls/jx-requirements.yml
@@ -1,6 +1,6 @@
 cluster:
   clusterName: bdd-boot-v
-  environmentGitOwner: jenkins-x-bot-test
+  environmentGitOwner: jenkins-x-versions-bot-test
   project: jenkins-x-bdd3
   provider: gke
   zone: europe-west1-c

--- a/jx/bdd/boot-vault-tls/parameters.yaml
+++ b/jx/bdd/boot-vault-tls/parameters.yaml
@@ -6,5 +6,5 @@ gpg: {}
 pipelineUser:
   github:
     host: github.com
-    username: jenkins-x-bot-test
+    username: jenkins-x-versions-bot-test
     email: jenkins-x@googlegroups.com

--- a/jx/bdd/boot-vault/ci.sh
+++ b/jx/bdd/boot-vault/ci.sh
@@ -2,9 +2,9 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
 export GH_EMAIL="jenkins-x@googlegroups.com"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/boot-vault/jx-requirements.yml
+++ b/jx/bdd/boot-vault/jx-requirements.yml
@@ -1,6 +1,6 @@
 cluster:
   clusterName: bdd-boot-v
-  environmentGitOwner: jenkins-x-bot-test
+  environmentGitOwner: jenkins-x-versions-bot-test
   project: jenkins-x-bdd3
   provider: gke
   zone: europe-west1-c

--- a/jx/bdd/boot-vault/parameters.yaml
+++ b/jx/bdd/boot-vault/parameters.yaml
@@ -6,5 +6,5 @@ gpg: {}
 pipelineUser:
   github:
     host: github.com
-    username: jenkins-x-bot-test
+    username: jenkins-x-versions-bot-test
     email: jenkins-x@googlegroups.com

--- a/jx/bdd/ekstekton/ci.sh
+++ b/jx/bdd/ekstekton/ci.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 export AWS_REGION="us-east-1"
 [[ -d ~/.aws ]] || mkdir ~/.aws

--- a/jx/bdd/gitops/ci.sh
+++ b/jx/bdd/gitops/ci.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/helm3/ci.sh
+++ b/jx/bdd/helm3/ci.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/knative-build/ci.sh
+++ b/jx/bdd/knative-build/ci.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/ng/ci.sh
+++ b/jx/bdd/ng/ci.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/tekton/ci.sh
+++ b/jx/bdd/tekton/ci.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/terraform-static/ci.sh
+++ b/jx/bdd/terraform-static/ci.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/bdd/terraform-tekton/ci.sh
+++ b/jx/bdd/terraform-tekton/ci.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
-export GH_OWNER="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
+export GH_OWNER="jenkins-x-versions-bot-test"
 
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"

--- a/jx/scripts/ci-github.sh
+++ b/jx/scripts/ci-github.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-export GH_USERNAME="jenkins-x-bot-test"
+export GH_USERNAME="jenkins-x-versions-bot-test"
 export GH_OWNER="cb-kubecd"
 
 # fix broken `BUILD_NUMBER` env var


### PR DESCRIPTION
We're using `jenkins-x-versions-bot-test` going forward.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>