### PR TITLE
WIP fix: reverting external-dns updates

### DIFF
--- a/charts/bitnami/external-dns.yml
+++ b/charts/bitnami/external-dns.yml
@@ -1,1 +1,1 @@
-version: 2.13.0
+version: 2.12.0

--- a/charts/stable/external-dns.yml
+++ b/charts/stable/external-dns.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/bitnami/charts/tree/master/bitnami/external-dns
-version: 2.13.0
+version: 2.12.0

--- a/charts/stable/prometheus.yml
+++ b/charts/stable/prometheus.yml
@@ -1,1 +1,1 @@
-version: 9.5.2
+version: 9.5.1

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,7 +4,7 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders.git) | [github.com/jenkins-x-charts/environment-controller](https://github.com/jenkins-x-charts/environment-controller) | [2.0.1065-392](https://github.com/jenkins-x/jenkins-x-builders/releases/tag/v2.0.1065-392) | **0.1.758**: [github.com/jenkins-x-charts/environment-controller](https://github.com/jenkins-x-charts/environment-controller)
 [jenkins-x/jx](https://github.com/jenkins-x/jx) | [github.com/jenkins-x-charts/environment-controller](https://github.com/jenkins-x-charts/environment-controller);[github.com/jenkins-x-charts/prow](https://github.com/jenkins-x-charts/prow);[github.com/jenkins-x/jenkins-x-builders-ml](https://github.com/jenkins-x/jenkins-x-builders-ml.git);[github.com/jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders.git) | [2.0.1065](https://github.com/jenkins-x/jx/releases/tag/v2.0.1065) | **2.0.806**: [github.com/jenkins-x-charts/environment-controller](https://github.com/jenkins-x-charts/environment-controller)
-[kubernetes-incubator/external-dns](https://github.com/kubernetes-incubator/external-dns) |  | [2.13.0]() | 
+[kubernetes-incubator/external-dns](https://github.com/kubernetes-incubator/external-dns) |  | [2.12.0]() | 
 [weaveworks/flagger](https://github.com/weaveworks/flagger) |  | [1.3.0]() | 
 [jenkins-x/dex](https://github.com/jenkins-x/dex) |  | [2.13.21]() | 
 [jenkins-x-charts/environment-controller](https://github.com/jenkins-x-charts/environment-controller) |  | [0.0.571](https://github.com/jenkins-x-charts/environment-controller/releases/tag/v0.0.571) | 
@@ -22,7 +22,7 @@ Dependency | Sources | Version | Mismatched versions
 [helm/charts](https://github.com/helm/charts/tree/master/stable/nginx-ingress) |  | [1.17.1]() | 
 [bitnami/charts](https://github.com/bitnami/charts/tree/master/bitnami/external-dns) |  | [2.10.2]() | 
 [grafana/grafana](https://github.com/grafana/grafana) |  | [4.1.3]() | 
-[prometheus/alertmanager](https://github.com/prometheus/alertmanager) |  | [9.5.2]() | 
+[prometheus/alertmanager](https://github.com/prometheus/alertmanager) |  | [9.5.1]() | 
 [weaveworks/flagger](https://github.com/weaveworks/flagger):flagger |  | [0.20.4](https://github.com/weaveworks/flagger/releases/tag/0.20.4) | 
 [weaveworks/flagger](https://github.com/weaveworks/flagger):grafana |  | [1.4.0]() | 
 [jenkins-x-charts/prow](https://github.com/jenkins-x-charts/prow):knative |  | []() | 
@@ -59,6 +59,6 @@ Dependency | Sources | Version | Mismatched versions
 [jenkins-x/jenkins-x-builders-base](https://github.com/jenkins-x/jenkins-x-builders-base) | [github.com/jenkins-x/jenkins-x-builders-ml](https://github.com/jenkins-x/jenkins-x-builders-ml.git);[github.com/jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders.git) | [0.0.72](https://github.com/jenkins-x/jenkins-x-builders-base/releases/tag/v0.0.72) | 
 [jenkins-x/bucketrepo](https://github.com/jenkins-x/bucketrepo) |  | [0.1.27]() | 
 [helm/cert-manager](https://github.com/helm/charts/tree/master/stable/cert-manager):cert-manager |  | [0.6.7]() | 
-[bitnami/external-dns](https://github.com/bitnami/charts/tree/master/bitnami/external-dns) |  | [2.13.0]() | 
+[bitnami/external-dns](https://github.com/bitnami/charts/tree/master/bitnami/external-dns) |  | [2.12.0]() | 
 [helm/nginx-ingress](https://github.com/helm/charts/tree/master/stable/nginx-ingress):nginx-ingress |  | [1.26.2]() | 
 [jenkins-x/jenkins-x-builders-base-image](https://github.com/jenkins-x/jenkins-x-builders-base-image) | [github.com/jenkins-x/jenkins-x-builders-ml](https://github.com/jenkins-x/jenkins-x-builders-ml.git) | [0.0.34]() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -62,7 +62,7 @@ dependencies:
   owner: kubernetes-incubator
   repo: external-dns
   url: https://github.com/kubernetes-incubator/external-dns
-  version: 2.13.0
+  version: 2.12.0
   versionURL: ""
 - host: github.com
   owner: weaveworks
@@ -170,7 +170,7 @@ dependencies:
   owner: prometheus
   repo: alertmanager
   url: https://github.com/prometheus/alertmanager
-  version: 9.5.2
+  version: 9.5.1
   versionURL: ""
 - component: flagger
   host: github.com
@@ -418,7 +418,7 @@ dependencies:
   owner: bitnami
   repo: external-dns
   url: https://github.com/bitnami/charts/tree/master/bitnami/external-dns
-  version: 2.13.0
+  version: 2.12.0
   versionURL: ""
 - component: nginx-ingress
   host: github.com


### PR DESCRIPTION
Reverts jenkins-x/jenkins-x-versions#701 because since that merged boot vault tests on jx have been failing and I’d like to verify whether this is the problem.