### PR TITLE
feat: Bump acceptable Helm2 version to versions less than 2.16.2

### DIFF
--- a/packages/helm.yml
+++ b/packages/helm.yml
@@ -1,4 +1,4 @@
 version: 2.12.2
-upperLimit: 2.15.0
+upperLimit: 2.16.2
 gitUrl: https://github.com/helm/helm
 url: https://helm.sh/


### PR DESCRIPTION
Improvements related to https://github.com/jenkins-x/jx/issues/6181, https://github.com/jenkins-x/jx/issues/6124, 