### PR TITLE
fix: remove the existing commands documentation before regenerating it

### DIFF
--- a/jx/scripts/update-jx-website.sh
+++ b/jx/scripts/update-jx-website.sh
@@ -15,6 +15,9 @@ then
     pushd $(mktemp -d)
       git clone https://github.com/jenkins-x/jx-docs.git
       pushd jx-docs/content/en/docs/reference/commands
+        # Cleanup the commands directory before generating new docs to avoid keeping the 
+        # deprecated commands of which doc is not anymore generated.
+        rm -rf *
         jx create docs
         git config credential.helper store
         git add *


### PR DESCRIPTION
As soon as a command is marked as deprecated, the documentation of that command is not anymore
generated, therefore we need to remove the documentation of all commands before regenerating the docs
to avoid having stall docs for commands which are deprecated.

fixes https://github.com/jenkins-x/jx/issues/6136