### PR TITLE
feat: Specify kubectl version compatible with JX

### DIFF
--- a/packages/kubectl.yml
+++ b/packages/kubectl.yml
@@ -1,4 +1,4 @@
 version: 1.13.2
-upperLimit: 2.0.0
+upperLimit: 1.17.0
 gitUrl: https://github.com/kubernetes/kubectl.git
 url: https://github.com/kubernetes/kubectl


### PR DESCRIPTION
The latest stable release of Kubectl seems to be causing issues with velero when used in JX. Therefore we've decided to limit the upper range of kubectl to version 1.16 as thats the last version of Kubectl that did not cause any problems with jx. 

Fixes https://github.com/jenkins-x/jx/issues/6511