### PR TITLE
feat: Added gcloud.yml to lock gcloud version.

### DIFF
--- a/packages/gcloud.yml
+++ b/packages/gcloud.yml
@@ -1,0 +1,4 @@
+version: 279.0.0
+gitUrl: https://github.com/GoogleCloudPlatform
+url: https://cloud.google.com/
+


### PR DESCRIPTION
Added gcloud.yml to lock the google cloud sdk version.
Closes : https://github.com/jenkins-x/jx/issues/6369