### PR TITLE
fix: setting a higher upper limit of 1.17.0 for helm binary

### DIFF
--- a/packages/helm.yml
+++ b/packages/helm.yml
@@ -1,4 +1,4 @@
 version: 2.12.2
-upperLimit: 2.16.2
+upperLimit: 2.17.0
 gitUrl: https://github.com/helm/helm
 url: https://helm.sh/


### PR DESCRIPTION
fixes https://github.com/jenkins-x/jx/issues/6760