### PR TITLE
fix: Upgrade to nginx-ingress 1.31.0

### DIFF
--- a/charts/stable/nginx-ingress.yml
+++ b/charts/stable/nginx-ingress.yml
@@ -1,3 +1,3 @@
 component: nginx-ingress
 gitUrl: https://github.com/helm/charts/tree/master/stable/nginx-ingress
-version: 1.28.3
+version: 1.31.0


### PR DESCRIPTION
1.29.0 through 1.30.x didn't work with k8s < 1.14, but that should be fixed now.

fixes https://github.com/jenkins-x/jx/issues/6517

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>