### PR TITLE
chore(deps): bump https://github.com/jenkins-x-labs/jxl from 0.0.69 to 0.0.77

### DIFF
--- a/charts/jx-labs/jxl-boot.yml
+++ b/charts/jx-labs/jxl-boot.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-labs/jxl
-version: 0.0.69
+version: 0.0.77

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -64,3 +64,4 @@ Dependency | Sources | Version | Mismatched versions
 [jenkins-x/jenkins-x-builders-base-image](https://github.com/jenkins-x/jenkins-x-builders-base-image) | [github.com/jenkins-x/jenkins-x-builders-ml](https://github.com/jenkins-x/jenkins-x-builders-ml.git) | [0.0.34]() | 
 [solo-io/gloo](https://github.com/solo-io/gloo) |  | [1.3.12](https://github.com/solo-io/gloo/releases/tag/v1.3.12) | 
 [jenkins-x-charts/jxboot-helmfile-resources](https://github.com/jenkins-x-charts/jxboot-helmfile-resources) |  | [0.0.84]() | 
+[jenkins-x-labs/jxl](https://github.com/jenkins-x-labs/jxl) |  | [0.0.77]() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -455,3 +455,9 @@ dependencies:
   url: https://github.com/jenkins-x-charts/jxboot-helmfile-resources
   version: 0.0.84
   versionURL: ""
+- host: github.com
+  owner: jenkins-x-labs
+  repo: jxl
+  url: https://github.com/jenkins-x-labs/jxl
+  version: 0.0.77
+  versionURL: ""

--- a/docker/gcr.io/jenkinsxio-labs/jxl.yml
+++ b/docker/gcr.io/jenkinsxio-labs/jxl.yml
@@ -1,1 +1,1 @@
-version: 0.0.69
+version: 0.0.77

--- a/jenkins-x-boot-helm3-mc.yml
+++ b/jenkins-x-boot-helm3-mc.yml
@@ -45,5 +45,5 @@ pipelineConfig:
                     name: sa
             steps:
               - command: jx/bdd/boot-helm3-mc/ci.sh
-                image: gcr.io/jenkinsxio-labs/jxl:0.0.69
+                image: gcr.io/jenkinsxio-labs/jxl:0.0.77
                 name: runci

--- a/jenkins-x-boot-helm3.yml
+++ b/jenkins-x-boot-helm3.yml
@@ -45,5 +45,5 @@ pipelineConfig:
                     name: sa
             steps:
               - command: jx/bdd/boot-helm3/ci.sh
-                image: gcr.io/jenkinsxio-labs/jxl:0.0.69
+                image: gcr.io/jenkinsxio-labs/jxl:0.0.77
                 name: runci

--- a/packages/jxl.yml
+++ b/packages/jxl.yml
@@ -1,4 +1,4 @@
-version: 0.0.69
+version: 0.0.77
 upperLimit: 1.0.0
 gitUrl: https://github.com/jenkins-x-labs/jxl
 url: https://jenkins-x.io/docs/labs/jxl/


### PR DESCRIPTION
Update [jenkins-x-labs/jxl](https://github.com/jenkins-x-labs/jxl) from [0.0.69](https://github.com/jenkins-x-labs/jxl/releases/tag/v0.0.69) to 0.0.77

Command run was `jx step create pr regex --regex version: (.*) --version 0.0.77 --files docker/gcr.io/jenkinsxio-labs/jxl.yml --files packages/jxl.yml --files charts/jx-labs/jxl-boot.yml --repo https://github.com/jenkins-x/jenkins-x-versions.git`
<hr />

Update [jenkins-x-labs/jxl](https://github.com/jenkins-x-labs/jxl) from [0.0.69](https://github.com/jenkins-x-labs/jxl/releases/tag/v0.0.69) to 0.0.77

Command run was `jx step create pr regex --regex \s+image: gcr.io/jenkinsxio-labs/jxl:(.*) --version 0.0.77 --files jenkins-x-*.yml --repo https://github.com/jenkins-x/jenkins-x-versions.git`