### PR TITLE
chore(deps): bump https://github.com/jenkins-x-labs/jxl from 0.0.90 to 0.0.93

### DIFF
--- a/charts/jx-labs/jxl-boot.yml
+++ b/charts/jx-labs/jxl-boot.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-labs/jxl
-version: 0.0.90
+version: 0.0.93

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -65,4 +65,4 @@ Dependency | Sources | Version | Mismatched versions
 [solo-io/gloo](https://github.com/solo-io/gloo) |  | [1.3.12](https://github.com/solo-io/gloo/releases/tag/v1.3.12) | 
 [jenkins-x-charts/jxboot-helmfile-resources](https://github.com/jenkins-x-charts/jxboot-helmfile-resources) |  | [0.0.85]() | 
 [kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns) |  | [2.19.2]() | 
-[jenkins-x-labs/jxl](https://github.com/jenkins-x-labs/jxl) |  | [0.0.90](https://github.com/jenkins-x-labs/jxl/releases/tag/v0.0.90) | 
+[jenkins-x-labs/jxl](https://github.com/jenkins-x-labs/jxl) |  | [0.0.93](https://github.com/jenkins-x-labs/jxl/releases/tag/v0.0.93) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -465,5 +465,5 @@ dependencies:
   owner: jenkins-x-labs
   repo: jxl
   url: https://github.com/jenkins-x-labs/jxl
-  version: 0.0.90
-  versionURL: https://github.com/jenkins-x-labs/jxl/releases/tag/v0.0.90
+  version: 0.0.93
+  versionURL: https://github.com/jenkins-x-labs/jxl/releases/tag/v0.0.93

--- a/docker/gcr.io/jenkinsxio-labs/jxl.yml
+++ b/docker/gcr.io/jenkinsxio-labs/jxl.yml
@@ -1,1 +1,1 @@
-version: 0.0.90
+version: 0.0.93

--- a/jenkins-x-boot-helm3-mc.yml
+++ b/jenkins-x-boot-helm3-mc.yml
@@ -45,5 +45,5 @@ pipelineConfig:
                     name: sa
             steps:
               - command: jx/bdd/boot-helm3-mc/ci.sh
-                image: gcr.io/jenkinsxio-labs/jxl:0.0.90
+                image: gcr.io/jenkinsxio-labs/jxl:0.0.93
                 name: runci

--- a/jenkins-x-boot-helm3.yml
+++ b/jenkins-x-boot-helm3.yml
@@ -45,5 +45,5 @@ pipelineConfig:
                     name: sa
             steps:
               - command: jx/bdd/boot-helm3/ci.sh
-                image: gcr.io/jenkinsxio-labs/jxl:0.0.90
+                image: gcr.io/jenkinsxio-labs/jxl:0.0.93
                 name: runci

--- a/packages/jxl.yml
+++ b/packages/jxl.yml
@@ -1,4 +1,4 @@
-version: 0.0.90
+version: 0.0.93
 upperLimit: 1.0.0
 gitUrl: https://github.com/jenkins-x-labs/jxl
 url: https://jenkins-x.io/docs/labs/jxl/


### PR DESCRIPTION
Update [jenkins-x-labs/jxl](https://github.com/jenkins-x-labs/jxl) from [0.0.90](https://github.com/jenkins-x-labs/jxl/releases/tag/v0.0.90) to [0.0.93](https://github.com/jenkins-x-labs/jxl/releases/tag/v0.0.93)

Command run was `jx step create pr regex --regex version: (.*) --version 0.0.93 --files docker/gcr.io/jenkinsxio-labs/jxl.yml --files packages/jxl.yml --files charts/jx-labs/jxl-boot.yml --repo https://github.com/jenkins-x/jenkins-x-versions.git`
<hr />

Update [jenkins-x-labs/jxl](https://github.com/jenkins-x-labs/jxl) from [0.0.90](https://github.com/jenkins-x-labs/jxl/releases/tag/v0.0.90) to [0.0.93](https://github.com/jenkins-x-labs/jxl/releases/tag/v0.0.93)

Command run was `jx step create pr regex --regex \s+image: gcr.io/jenkinsxio-labs/jxl:(.*) --version 0.0.93 --files jenkins-x-*.yml --repo https://github.com/jenkins-x/jenkins-x-versions.git`