### PR TITLE
feat: add vmware-tanzu velero to versions

### DIFF
--- a/apps/vmware-tanzu/velero/README.MD
+++ b/apps/vmware-tanzu/velero/README.MD
@@ -1,0 +1,6 @@
+# velero
+
+|App Metadata||
+|---|---|
+| **Version** | 2.12.0 |
+| **Chart Repository** | https://vmware-tanzu.github.io/helm-charts |

--- a/apps/vmware-tanzu/velero/defaults.yml
+++ b/apps/vmware-tanzu/velero/defaults.yml
@@ -1,0 +1,2 @@
+namespace: velero
+phase: system

--- a/apps/vmware-tanzu/velero/values.yaml.gotmpl
+++ b/apps/vmware-tanzu/velero/values.yaml.gotmpl
@@ -1,0 +1,72 @@
+{{- if and (hasKey .Values.jxRequirements "velero") (hasKey .Values.jxRequirements.velero "namespace") }}
+{{- if .Values.jxRequirements.velero.namespace }}
+enabled: true
+{{- else }}
+enabled: false
+{{- end }}
+{{- else }}
+enabled: false
+{{- end }}
+rbac:
+  create: true
+credentials:
+  useSecret: true
+  existingSecret: velero-secret
+{{- if eq .Values.jxRequirements.cluster.provider "gke" }}
+configuration:
+  provider: gcp
+  backupStorageLocation:
+    name: gcp
+    bucket: {{ .Values.jxRequirements.storage.backup.url | quote }}
+initContainers:
+- name: velero-plugin-for-gcp
+  image: velero/velero-plugin-for-gcp:v1.1.0
+  volumeMounts:
+  - mountPath: /target
+    name: plugins
+{{- else if or (eq .Values.jxRequirements.cluster.provider "aws") (eq .Values.jxRequirements.cluster.provider "eks") }}
+configuration:
+  provider: aws
+  backupStorageLocation:
+    name: aws
+    bucket: {{ .Values.jxRequirements.storage.backup.url | quote }}
+    config:
+      region: {{ .Values.jxRequirements.cluster.region | quote }}
+initContainers:
+- name: velero-plugin-for-aws
+  image: velero/velero-plugin-for-aws:v1.1.0
+  volumeMounts:
+  - mountPath: /target
+    name: plugins
+{{- else if eq .Values.jxRequirements.cluster.provider "azure" }}
+configuration:
+  provider: azure
+  backupStorageLocation:
+    name: azure
+    bucket: {{ .Values.jxRequirements.storage.backup.url | quote }}
+    config:
+      storageAccount: {{ .Values.jxRequirements.velero.serviceAccount | quote }}
+initContainers:
+- name: velero-plugin-for-microsoft-azure
+  image: velero/velero-plugin-for-microsoft-azure:v1.1.0
+  volumeMounts:
+  - mountPath: /target
+    name: plugins
+{{- else if eq .Values.jxRequirements.cluster.provider "iks" }}
+snapshotsEnabled: false
+configuration:
+  provider: aws
+  backupStorageLocation:
+    name: aws
+    bucket: bucket-name
+    config:
+      region: {{ .Values.jxRequirements.cluster.region | quote }}
+      s3ForcePathStyle: "true"
+      s3Url: {{ .Values.jxRequirements.storage.backup.url | quote }}
+initContainers:
+- name: velero-plugin-for-aws
+  image: velero/velero-plugin-for-aws:v1.1.0
+  volumeMounts:
+  - mountPath: /target
+    name: plugins
+{{- end }}

--- a/charts/repositories.yml
+++ b/charts/repositories.yml
@@ -18,3 +18,6 @@ repositories:
   - prefix: gloo
     urls:
       - https://storage.googleapis.com/solo-public-helm
+  - prefix: vmware-tanzu
+    urls:
+      - https://vmware-tanzu.github.io/helm-charts

--- a/charts/vmware-tanzu/velero.yml
+++ b/charts/vmware-tanzu/velero.yml
@@ -1,0 +1,3 @@
+component: velero
+gitUrl: https://github.com/vmware-tanzu/velero
+version: 1.4.0

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -55,7 +55,7 @@ Dependency | Sources | Version | Mismatched versions
 [jenkins-x-quickstarts/spring-boot-rest-prometheus-java11](https://github.com/jenkins-x-quickstarts/spring-boot-rest-prometheus-java11.git) |  | [1.0.0+7e487fce2]() | 
 [jenkins-x-quickstarts/spring-boot-watch-pipeline-activity](https://github.com/jenkins-x-quickstarts/spring-boot-watch-pipeline-activity.git) |  | [1.0.0+177d75201]() | 
 [jenkins-x-quickstarts/vertx-rest-prometheus](https://github.com/jenkins-x-quickstarts/vertx-rest-prometheus.git) |  | [1.0.0+fd180fd76]() | 
-[heptio/velero](https://github.com/heptio/velero):velero |  | [2.7.4]() | 
+[vmware-tanzu/velero](https://github.com/vmware-tanzu/velero):velero |  | [1.4.0]() | 
 [jenkins-x/jenkins-x-builders-base](https://github.com/jenkins-x/jenkins-x-builders-base) | [github.com/jenkins-x/jenkins-x-builders-ml](https://github.com/jenkins-x/jenkins-x-builders-ml.git);[github.com/jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders.git) | [0.0.79](https://github.com/jenkins-x/jenkins-x-builders-base/releases/tag/v0.0.79) | 
 [jenkins-x/bucketrepo](https://github.com/jenkins-x/bucketrepo) |  | [0.1.40]() | 
 [helm/cert-manager](https://github.com/helm/charts/tree/master/stable/cert-manager):cert-manager |  | [0.6.7]() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -371,10 +371,10 @@ dependencies:
   versionURL: ""
 - component: velero
   host: github.com
-  owner: heptio
+  owner: vmware-tanzu
   repo: velero
-  url: https://github.com/heptio/velero
-  version: 2.7.4
+  url: https://github.com/vmware-tanzu/velero
+  version: 1.4.0
   versionURL: ""
 - host: github.com
   owner: jenkins-x


### PR DESCRIPTION
Was curious of level of effort to move off of deprecated velero chart to new official chart:
https://hub.helm.sh/charts/vmware-tanzu/velero

Are there integration tests for Velero? To be honest, I just changed the configs, and have not actually tested this locally.